### PR TITLE
pnginfo with -d option does not dump full bitmap

### DIFF
--- a/pnginfo.c
+++ b/pnginfo.c
@@ -406,7 +406,7 @@ pnginfo_displayfile (char *filename, int extractBitmap, int displayBitmap, int t
 	  // This currently only applies to runs on zeros -- I should one day add an
 	  // option to extend this to runs of other values as well
 	  runlen = 0;
-	  for (i = 0; i < rowbytes * height / png_get_channels(png, info); i += png_get_channels(png, info) * bytespersample)
+	  for (i = 0; i < rowbytes * height; i += png_get_channels(png, info) * bytespersample)
 	    {
 	      int scount, bcount, pixel;
 


### PR DESCRIPTION
Using pnginfo with -d option on PNG file dumps only part of the bitmap.
This happens on any PNG file. Here is a transcript:
$ pnginfo test.png
test.png...
  Image Width: 279 Image Length: 266
  Bitdepth (Bits/Sample): 16
  Channels (Samples/Pixel): 3
  Pixel depth (Pixel Depth): 48
  Colour Type (Photometric Interpretation): RGB
  Image filter: Single row per byte filter
  Interlacing: No interlacing
  Compression Scheme: Deflate method 8, 32k window
  Resolution: 0, 0 (unit unknown)
  FillOrder: msb-to-lsb
  Byte Order: Network (Big Endian)
  Number of text strings: 0 of 0
  Offsets: 0, 0

$ pnginfo -d test.png | sed 's/] /]\n/g' | grep '\[' | wc -l
24738
$

I expect 74214 number in last command, because the number of pixels in
this file is 279 * 266 = 74214.