### PR TITLE
Move man page generation into the makefiles & update configure.ac

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install libpng
-        run: sudo apt-get install -y libpng-dev
+        run: sudo apt-get install -y libpng-dev docbook-utils
       - name: aclocal
         run: aclocal
       - name: autoconf
@@ -27,4 +27,4 @@ jobs:
       - name: make
         run: make
       - name: make install
-        run: make install
+        run: make install DESTDIR="$PWD/install"

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS = man
+
 bin_PROGRAMS = pnginfo pngcp pngchunkdesc pngchunks
 
 pnginfo_SOURCES = pnginfo.c

--- a/configure.ac
+++ b/configure.ac
@@ -34,4 +34,5 @@ dnl Checks for library functions.
 AC_FUNC_VPRINTF
 dnl AC_FUNC_SNPRINTF
 
-AC_OUTPUT(Makefile)
+AC_CONFIG_FILES([Makefile man/Makefile])
+AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,9 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT(pnginfo.c)
+AC_INIT(pngtools, [0.4-dev])
+AC_CONFIG_SRCDIR([pnginfo.c])
 AC_CONFIG_AUX_DIR(config)
 AC_REVISION
-AM_INIT_AUTOMAKE(pngtools, 0.2)
+AM_INIT_AUTOMAKE
 AM_MAINTAINER_MODE
 
 dnl Checks for programs.
@@ -14,16 +15,11 @@ dnl The syntax is library name, function, action if found, action if not found
 dnl We just use the default if found action which adds -l<lib> to the LIBS var
 dnl and #defined HAVE_LIB<lib>
 
-
 dnl -lm:
 AC_CHECK_LIB(m, atan)
 
 dnl -lpng:
-AC_CHECK_LIB(png, png_libpng_ver)
-
-dnl STDC checks for stdlib.h stdarg.h string.h and float.h
-AC_HEADER_STDC
-AC_CHECK_HEADERS(stdio.h)
+AC_SEARCH_LIBS(png_read_image, png, [], [AC_MSG_ERROR([libpng not found])])
 
 dnl Headers for libraries
 AC_CHECK_HEADERS(png.h)

--- a/makerelease
+++ b/makerelease
@@ -6,40 +6,26 @@ cd man
 rm *sgml || true
 cd ..
 
-for item in `ls *.c`
+for item in *.c
 do
-  /data/src/stillhq_public/trunk/autodocbook/autodocbook $item
+  /data/src/stillhq_public/trunk/autodocbook/autodocbook "$item"
 done
 
-cd man
-for item in `ls *sgml`
-do
-  docbook2man $item
-done
-cd ..
-
-automake
-autoconf
+autoreconf -if
 ./configure
+make -C man
 make clean
 
 # Get rid of core files
-for item in `find . | grep core`
-do
-  rm -i $item
-done
+find . -name "*core*" -exec rm -rf {} ";"
 
 # Get rid of unwanted files
 for filename in Makefile autom4te.cache config.cache config.log config.status logfile math config.h output.pdf .deps
 do
-  for item in `find . -name $filename -print`
-  do
-    rm -rf $item || true
-  done
+  find . -name "$filename" -exec rm -rf {} ";"
 done
 
-rm -ri "#*#" || true
-rm -ri *~ || true
+rm -ri "#*#" *~ || true
 
 # How much space do we use?
 du -sk

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,0 +1,6 @@
+.sgml.1:
+	docbook2man $<
+
+EXTRA_DIST = docbook pngchunkdesc.sgml pngchunks.sgml pngcp.sgml pnginfo.sgml
+
+man_MANS = pngchunkdesc.1 pngchunks.1 pngcp.1 pnginfo.1


### PR DESCRIPTION
The makerelease script now uses that to generate the man pages.
autoreconf no longer complains about obsolete autoconf macros.