### PR TITLE
Update pnginfo.c to fix build failure

### DIFF
--- a/pnginfo.c
+++ b/pnginfo.c
@@ -416,7 +416,7 @@ pnginfo_displayfile (char *filename, int extractBitmap, int displayBitmap, int t
 	      else if (runlen != 0)
 		{
 		  if (runlen > 1)
-		    printf ("* %d ", runlen);
+		    printf ("* %ld ", runlen);
 		  runlen = 0;
 		}
 


### PR DESCRIPTION
Fix build failure with newer compilers and glibc and security flags:
gcc -DPACKAGE_NAME=\"pngtools\" -DPACKAGE_TARNAME=\"pngtools\" -DPACKAGE_VERSION=\"0.4-dev\" -DPACKAGE_STRING=\"pngtools\ 0.4-dev\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"pngtools\" -DVERSION=\"0.4-dev\" -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_PNG_H=1 -I.   -Wdate-time -D_FORTIFY_SOURCE=2  -Werror -c -o pngread.o pngread.c
pnginfo.c: In function 'pnginfo_displayfile':
pnginfo.c:419:33: error: format '%d' expects argument of type 'int', but argument 2 has type 'long unsigned int' [-Werror=format=]
  419 |                     printf ("* %d ", runlen);
      |                                ~^    ~~~~~~
      |                                 |    |
      |                                 int  long unsigned int
      |                                %ld
gcc -DPACKAGE_NAME=\"pngtools\" -DPACKAGE_TARNAME=\"pngtools\" -DPACKAGE_VERSION=\"0.4-dev\" -DPACKAGE_STRING=\"pngtools\ 0.4-dev\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"pngtools\" -DVERSION=\"0.4-dev\" -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_PNG_H=1 -I.   -Wdate-time -D_FORTIFY_SOURCE=2  -Werror -c -o pngwrite.o pngwrite.c