### PR TITLE
Fix pnginfo output for palette image colors

### DIFF
--- a/pngchunks.c
+++ b/pngchunks.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
   while(!lastchunk)
     {
       head = (pngchunks_header *) offset;
-      printf("Chunk: Data Length %d (max %d), Type %d [%c%c%c%c]\n", 
+      printf("Chunk: Data Length %u (max %u), Type %d [%c%c%c%c]\n",
 	     ntohl(head->len), 
 	     (unsigned int) pow(2, 31) - 1,
 	     head->type.i,
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
 
       if(strncmp(head->type.c, "IHDR", 4) == 0)
 	{
-	  printf("  IHDR Width: %d\n  IHDR Height: %d\n  IHDR Bitdepth: %d\n  IHDR Colortype: %d\n  IHDR Compression: %d\n  IHDR Filter: %d\n  IHDR Interlace: %d\n",
+	  printf("  IHDR Width: %u\n  IHDR Height: %u\n  IHDR Bitdepth: %u\n  IHDR Colortype: %u\n  IHDR Compression: %u\n  IHDR Filter: %u\n  IHDR Interlace: %u\n",
 		 ntohl(((pngchunks_IHDR *) offset)->width),
 		 ntohl(((pngchunks_IHDR *) offset)->height),
 		 ((pngchunks_IHDR *) offset)->bitdepth,
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
       }
 
       offset += ntohl(head->len);
-      printf("  Chunk CRC: %d\n", ntohl(*((long *) offset)));
+      printf("  Chunk CRC: %u\n", ntohl(*((long *) offset)));
       offset += 4;
     }
 

--- a/pnginfo.c
+++ b/pnginfo.c
@@ -185,17 +185,17 @@ pnginfo_displayfile (char *filename, int extractBitmap, int displayBitmap, int t
   // Start displaying information
   ///////////////////////////////////////////////////////////////////////////
 
-  printf ("  Image Width: %d Image Length: %d\n", width, height);
+  printf ("  Image Width: %u Image Length: %u\n", width, height);
   int pixel_depth;
   pixel_depth = bitdepth * png_get_channels(png, info);
   if(tiffnames == pnginfo_true){
     printf ("  Bits/Sample: %d\n", bitdepth);
-    printf ("  Samples/Pixel: %d\n", png_get_channels(png, info));
+    printf ("  Samples/Pixel: %u\n", png_get_channels(png, info));
     printf ("  Pixel Depth: %d\n", pixel_depth);	// Does this add value?
   }
   else{
     printf ("  Bitdepth (Bits/Sample): %d\n", bitdepth);
-    printf ("  Channels (Samples/Pixel): %d\n", png_get_channels(png, info));
+    printf ("  Channels (Samples/Pixel): %u\n", png_get_channels(png, info));
     printf ("  Pixel depth (Pixel Depth): %d\n", pixel_depth);	// Does this add value?
   }
 
@@ -288,7 +288,7 @@ pnginfo_displayfile (char *filename, int extractBitmap, int displayBitmap, int t
   int phys_unit_type;
   png_get_pHYs (png, info, &x_pixels_per_unit, &y_pixels_per_unit, &phys_unit_type);
 
-  printf ("  Resolution: %d, %d ",
+  printf ("  Resolution: %u, %u ",
 	  x_pixels_per_unit, y_pixels_per_unit);
   switch (phys_unit_type)
     {
@@ -398,7 +398,7 @@ pnginfo_displayfile (char *filename, int extractBitmap, int displayBitmap, int t
 	    bytespersample++;
 
 	  printf ("Dumping the bitmap for this image:\n");
-	  printf ("(Expanded samples result in %d bytes per pixel, %d channels with %d bytes per channel)\n\n", 
+	  printf ("(Expanded samples result in %d bytes per pixel, %u channels with %d bytes per channel)\n\n",
 		  png_get_channels(png, info) * bytespersample, png_get_channels(png, info), bytespersample);
 
 	  // runlen is used to stop us displaying repeated byte patterns over and over --

--- a/pnginfo.c
+++ b/pnginfo.c
@@ -201,8 +201,9 @@ pnginfo_displayfile (char *filename, int extractBitmap, int displayBitmap, int t
   // Photometric interp packs a lot of information
   printf ("  Colour Type (Photometric Interpretation): ");
 
-  int num_palette;
-  int num_trans;
+  int num_palette = 0;
+  int num_trans = 0;
+  png_colorp palette;
 
   switch (colourtype)
     {
@@ -212,10 +213,16 @@ pnginfo_displayfile (char *filename, int extractBitmap, int displayBitmap, int t
 
     case PNG_COLOR_TYPE_PALETTE:
       printf ("PALETTED COLOUR ");
-      if (num_trans > 0)
-	printf ("with alpha ");
-      printf ("(%d colours, %d transparent) ",
-	      num_palette, num_trans);
+      if (PNG_INFO_PLTE == png_get_PLTE(png, info, &palette, &num_palette)) {
+        png_bytep trans;
+        png_color_16p trans_values;
+        if (PNG_INFO_tRNS == png_get_tRNS(png, info, &trans, &num_trans, &trans_values)){
+          if (num_trans > 0)
+            printf ("with alpha ");
+        }
+        printf ("(%d colours, %d transparent) ",
+                num_palette, num_trans);
+      }
       break;
 
     case PNG_COLOR_TYPE_RGB:

--- a/pnginfo.c
+++ b/pnginfo.c
@@ -138,8 +138,7 @@ pnginfo_displayfile (char *filename, int extractBitmap, int displayBitmap, int t
 {
   FILE *image;
   png_uint_32 width, height;
-  unsigned long imageBufSize, runlen;
-  unsigned char signature;
+  unsigned long runlen;
   int bitdepth, colourtype;
   png_uint_32 i, j, rowbytes;
   png_structp png;

--- a/pngread.c
+++ b/pngread.c
@@ -10,7 +10,7 @@ char *readimage(char *filename, png_uint_32 *width, png_uint_32 *height,
 char *readimage(char *filename, png_uint_32 *width, png_uint_32 *height, 
 		      int *bitdepth, int *channels){
   FILE *image;
-  png_uint_32 i, j, rowbytes;
+  png_uint_32 i, rowbytes;
   png_structp png;
   png_infop info;
   png_bytepp row_pointers = NULL;


### PR DESCRIPTION
This has been broken for a long while.

Also, delete unused variables and fix signedness in printf format specifiers.