### PR TITLE
Fix resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.deps
+*.o
+*.swp
+Makefile
+config.log
+config.status
+pngchunkdesc
+pngchunks
+pngcp
+pnginfo

--- a/configure
+++ b/configure
@@ -3470,8 +3470,8 @@ fi
 
 
 
-{ echo "$as_me:$LINENO: checking for png_libpng_ver in -lpng" >&5
-echo $ECHO_N "checking for png_libpng_ver in -lpng... $ECHO_C" >&6; }
+{ echo "$as_me:$LINENO: checking for png_access_version_number in -lpng" >&5
+echo $ECHO_N "checking for png_access_version_number in -lpng... $ECHO_C" >&6; }
 if test "${ac_cv_lib_png_png_libpng_ver+set}" = set; then
   echo $ECHO_N "(cached) $ECHO_C" >&6
 else
@@ -3490,11 +3490,11 @@ cat >>conftest.$ac_ext <<_ACEOF
 #ifdef __cplusplus
 extern "C"
 #endif
-char png_libpng_ver ();
+char png_access_version_number ();
 int
 main ()
 {
-return png_libpng_ver ();
+return png_access_version_number ();
   ;
   return 0;
 }

--- a/pnginfo.c
+++ b/pnginfo.c
@@ -284,8 +284,8 @@ pnginfo_displayfile (char *filename, int extractBitmap, int displayBitmap, int t
     }
   printf ("\n");
 
-  png_uint_32 x_pixels_per_unit, y_pixels_per_unit;
-  int phys_unit_type;
+  png_uint_32 x_pixels_per_unit = 0, y_pixels_per_unit = 0;
+  int phys_unit_type = PNG_RESOLUTION_UNKNOWN;
   png_get_pHYs (png, info, &x_pixels_per_unit, &y_pixels_per_unit, &phys_unit_type);
 
   printf ("  Resolution: %d, %d ",

--- a/pnginfo.c
+++ b/pnginfo.c
@@ -156,8 +156,8 @@ pnginfo_displayfile (char *filename, int extractBitmap, int displayBitmap, int t
     pnginfo_error ("Could not open the specified PNG file.");
 
   // Check that it really is a PNG file
-  fread (sig, 1, 8, image);
-  if (!png_sig_cmp(sig, 0, 8) == 0)
+  if(fread(sig, 1, 8, image) != 8 ||
+     !png_sig_cmp(sig, 0, 8) == 0)
     pnginfo_error ("This file is not a valid PNG file.");
 
   // Start decompressing

--- a/pngread.c
+++ b/pngread.c
@@ -25,8 +25,8 @@ char *readimage(char *filename, png_uint_32 *width, png_uint_32 *height,
   }
 
   // Check that it really is a PNG file
-  fread(sig, 1, 8, image);
-  if(!png_sig_cmp(sig, 0, 8) == 0){
+  if(fread(sig, 1, 8, image) != 8 ||
+     !png_sig_cmp(sig, 0, 8) == 0){
     fprintf(stderr, "This file is not a valid PNG file\n");
     goto error;
   }

--- a/pngread.c
+++ b/pngread.c
@@ -11,7 +11,7 @@ char *readimage(char *filename, png_uint_32 *width, png_uint_32 *height,
 		      int *bitdepth, int *channels){
   FILE *image;
   png_uint_32 i, j, rowbytes;
-  png_structp png;
+  png_structp png = NULL;
   png_infop info;
   png_bytepp row_pointers = NULL;
   unsigned char sig[8];


### PR DESCRIPTION
This PR contains:
- a major fix for pnginfo in the commit "pnginfo should not print resolution from previous files" (the reason I started work on this at all)
- a minor fix to make pngcp not segfault when given a tiny input file in the commit "fix segmentation fault on some errors" 
- a minor patch to make pngcp and pnginfo compile without warnings with modern gcc in the commit "avoid warning for ignoring return value"
- a quick workaround to make ./configure find libpng in "Make sure ./configure adds -lpng to LIBS in Makefile"
- a .gitignore to make it easy to cleanly work with git in this repo

The last three mentioned commits should allow anyone to check out the repo and run `./configure; make` to cleanly compile the code.

I'd be happy to split it up further if you want, but the changes are all pretty small, and they're already split up by commit.