### PR TITLE
Add release workflow with Sigstore signing.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (must match configure.ac)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify version matches configure.ac
+        run: |
+          ac_version=$(sed -n 's/^AC_INIT(pngtools, \[\(.*\)\])/\1/p' configure.ac)
+          if [ "$ac_version" != "${{ inputs.version }}" ]; then
+            echo "::error::Version mismatch: configure.ac has '$ac_version' but release requested '${{ inputs.version }}'"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpng-dev docbook-utils
+
+      - name: Build
+        run: |
+          aclocal
+          autoconf
+          automake --add-missing
+          autoreconf
+          ./configure
+          make
+
+      - name: Test
+        run: |
+          python3 -m venv tests/.venv
+          tests/.venv/bin/pip install -r test-requirements.txt
+          tests/.venv/bin/python tests/generate_test_images.py
+          tests/.venv/bin/stestr run
+
+      - name: Create distribution tarball
+        run: make dist
+
+      - name: Set up gitsign
+        uses: chainguard-dev/actions/setup-gitsign@main
+
+      - name: Create signed tag
+        run: |
+          git tag -s -m "Release v${{ inputs.version }}" "v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+
+      - name: Generate changelog
+        run: |
+          prev_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$prev_tag" ]; then
+            echo "## Changelog" > changelog.md
+            echo "" >> changelog.md
+            echo "Initial release." >> changelog.md
+            echo "" >> changelog.md
+            echo '```' >> changelog.md
+            git log --oneline --no-merges >> changelog.md
+            echo '```' >> changelog.md
+          else
+            echo "## Changelog (since $prev_tag)" > changelog.md
+            echo "" >> changelog.md
+            echo '```' >> changelog.md
+            git log --oneline --no-merges "$prev_tag"..HEAD >> changelog.md
+            echo '```' >> changelog.md
+          fi
+
+      - name: Create GitHub Release
+        run: |
+          gh release create "v${{ inputs.version }}" \
+            --title "pngtools ${{ inputs.version }}" \
+            --notes-file changelog.md \
+            "pngtools-${{ inputs.version }}.tar.gz"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Attest tarball provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "pngtools-${{ inputs.version }}.tar.gz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,19 +66,23 @@ jobs:
         run: |
           prev_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -z "$prev_tag" ]; then
-            echo "## Changelog" > changelog.md
-            echo "" >> changelog.md
-            echo "Initial release." >> changelog.md
-            echo "" >> changelog.md
-            echo '```' >> changelog.md
-            git log --oneline --no-merges >> changelog.md
-            echo '```' >> changelog.md
+            {
+              echo "## Changelog"
+              echo ""
+              echo "Initial release."
+              echo ""
+              echo '```'
+              git log --oneline --no-merges
+              echo '```'
+            } > changelog.md
           else
-            echo "## Changelog (since $prev_tag)" > changelog.md
-            echo "" >> changelog.md
-            echo '```' >> changelog.md
-            git log --oneline --no-merges "$prev_tag"..HEAD >> changelog.md
-            echo '```' >> changelog.md
+            {
+              echo "## Changelog (since $prev_tag)"
+              echo ""
+              echo '```'
+              git log --oneline --no-merges "$prev_tag"..HEAD
+              echo '```'
+            } > changelog.md
           fi
 
       - name: Create GitHub Release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 repos:
   - repo: local
     hooks:
+      # Note: actionlint and shellcheck run in separate pre-commit
+      # environments (golang vs python), so actionlint cannot use
+      # shellcheck to lint inline 'run:' scripts in workflows here.
+      # CI catches those issues because both are system-installed.
       - id: actionlint
         name: actionlint
         entry: actionlint

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,7 +111,7 @@ autoreconf && ./configure && make`
 
 ## CI
 
-Two GitHub Actions workflows:
+Three GitHub Actions workflows:
 
 **CI** (`.github/workflows/c.yml`): runs actionlint, shellcheck,
 clang-format, and cppcheck checks first, then builds on Ubuntu
@@ -123,6 +123,13 @@ images, and runs the full test suite via stestr.
 **CodeQL** (`.github/workflows/codeql.yml`): runs on push, PR,
 and weekly schedule. Performs deep semantic security and quality
 analysis of the C source code.
+
+**Release** (`.github/workflows/release.yml`): manually triggered
+via `workflow_dispatch`. Takes a version input (must match
+`configure.ac`), builds and tests the project, creates a `make
+dist` tarball, creates a Sigstore-signed git tag via gitsign,
+publishes a GitHub Release with the tarball attached, and attests
+the tarball provenance with `actions/attest-build-provenance`.
 
 Five pre-commit hooks run automatically before each commit:
 1. **actionlint** -- validates workflow YAML

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,5 +9,7 @@ pngcp_SOURCES = pngcp.c pngread.c pngwrite.c inflateraster.c
 pngchunkdesc_SOURCES = pngchunkdesc.c
 pngchunks_SOURCES = pngchunks.c
 
+noinst_HEADERS = pngcp.h chunk_meanings.h
+
 pnginfo_LDADD = -lpng
 pngcp_LDADD = -lpng -lm

--- a/README.md
+++ b/README.md
@@ -98,6 +98,27 @@ scripts/check-format.sh       # check only
 scripts/check-format.sh fix   # auto-format in place
 ```
 
+## Releasing
+
+1. Update the version in `configure.ac` (`AC_INIT(pngtools, [X.Y])`)
+2. Commit and push to `master`
+3. Go to **Actions > Release > Run workflow**
+4. Enter the version string (must match `configure.ac`)
+
+The workflow will:
+- Verify the version matches `configure.ac`
+- Build and run the full test suite
+- Create a `make dist` tarball
+- Create a Sigstore-signed git tag (`vX.Y`)
+- Publish a GitHub Release with the tarball and changelog
+- Attest the tarball provenance via Sigstore
+
+Release artifacts can be verified with:
+
+```bash
+gh attestation verify pngtools-X.Y.tar.gz --owner mikalstill
+```
+
 ## Documentation
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) -- code structure, data flow,


### PR DESCRIPTION
Add a manually-triggered GitHub Actions workflow that creates Sigstore-signed tags via gitsign, builds a make dist tarball, publishes a GitHub Release with a changelog, and attests the tarball with actions/attest-build-provenance.

Also fix make dist to include pngcp.h and chunk_meanings.h via noinst_HEADERS, and document the release process in the README.

Prompt: What should we do in terms of release automation via github workflows? Can I automate signed release tags with SigStore? (Then: include git log in release notes and document the release process in the readme.)