### PR TITLE
Include test suite in release tarball.

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,7 +78,9 @@ GNU Autotools (autoconf + automake):
   symbol), libm (`atan` symbol), and `png.h`.
 - **Makefile.am**: Builds four binaries. pnginfo and pngchunks are
   standalone; pngcp links pngread.c, pngwrite.c, and inflateraster.c.
-  pngcp additionally links libm.
+  pngcp additionally links libm. `EXTRA_DIST` includes the test
+  suite, test images, stestr config, and test requirements so that
+  `make dist` tarballs contain everything needed to run tests.
 - **man/**: DocBook SGML man page sources (`man/*.sgml.in`), built
   to man pages via `docbook2man`. The `.sgml.in` templates use
   `@PACKAGE_VERSION@` which `configure` substitutes from

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,3 +13,19 @@ noinst_HEADERS = pngcp.h chunk_meanings.h
 
 pnginfo_LDADD = -lpng
 pngcp_LDADD = -lpng -lm
+
+EXTRA_DIST = \
+	.stestr.conf \
+	test-requirements.txt \
+	sample.png \
+	input.png \
+	foursamplesperpixel.png \
+	grayscale.png \
+	multibytesample.png \
+	tests/__init__.py \
+	tests/base.py \
+	tests/generate_test_images.py \
+	tests/test_pngchunkdesc.py \
+	tests/test_pngchunks.py \
+	tests/test_pngcp.py \
+	tests/test_pnginfo.py

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ scripts/check-format.sh fix   # auto-format in place
 The workflow will:
 - Verify the version matches `configure.ac`
 - Build and run the full test suite
-- Create a `make dist` tarball
+- Create a `make dist` tarball (includes test suite and test images)
 - Create a Sigstore-signed git tag (`vX.Y`)
 - Publish a GitHub Release with the tarball and changelog
 - Attest the tarball provenance via Sigstore


### PR DESCRIPTION
Add EXTRA_DIST to Makefile.am so that `make dist` tarballs include the test suite, test images, stestr config, and test requirements. This allows users to verify their build by running the tests from the release tarball.

Closes #32.

Prompt: Tests were excluded from the release tarball due to size concerns. After investigation, the 70MB tests/ directory was mostly the Python venv (excluded by .gitignore). The actual test files add only ~612KB to the tarball, so we included them directly rather than offering a separate download.