### PR TITLE
Show tEXt chunks placed after IDAT in pnginfo.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Summary
 
-pngtools is a small C project (~1,100 lines across 7 source files)
+pngtools is a small C project (7 source files)
 providing four command-line PNG utilities: pnginfo, pngchunks,
 pngchunkdesc, and pngcp. It uses libpng for PNG I/O and GNU Autotools
 for building. See ARCHITECTURE.md for detailed structure and known
@@ -20,7 +20,7 @@ Dependencies: libpng-dev, libm, docbook-utils (for man pages).
 
 ## Testing
 
-55 automated tests using Python testtools + stestr:
+Automated tests use Python testtools + stestr:
 
 ```bash
 # One-time setup
@@ -108,6 +108,6 @@ Or run individual checks manually:
   the corresponding `.sgml.in` man page template as well.
 
 - **CI runs the full test suite.** The GitHub Actions CI workflow
-  builds the project and runs all 55 tests. A separate CodeQL
+  builds the project and runs the full test suite. A separate CodeQL
   workflow performs security and quality analysis. PRs must pass
   both CI checks.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,7 +9,7 @@ from 2001 and uses GNU Autotools for its build system.
 
 ## Tools
 
-### pnginfo (pnginfo.c, ~440 lines)
+### pnginfo (pnginfo.c)
 
 The primary tool. Reads PNG files via libpng and displays metadata:
 image dimensions, bit depth, colour type, interlacing, compression,
@@ -23,7 +23,7 @@ resolution, and embedded text chunks. Has three modes:
 The bitmap dump includes run-length compression for zero-valued
 pixels, printing them once and then showing a repeat count.
 
-### pngchunks (pngchunks.c, ~190 lines)
+### pngchunks (pngchunks.c)
 
 Lists the raw chunk structure of a PNG file. Unlike pnginfo, this tool
 does **not** use libpng -- it memory-maps the file with `mmap()` and
@@ -34,13 +34,13 @@ is decoded to show its case-encoded properties (critical/ancillary,
 public/private, etc.). All pointer advances are bounds-checked against
 the mmap'd region to prevent segfaults on malformed input.
 
-### pngchunkdesc (pngchunkdesc.c, ~48 lines)
+### pngchunkdesc (pngchunkdesc.c)
 
 A stdin/stdout filter that reads four-character PNG chunk names and
 decodes the case information embedded in each letter. Uses the shared
 `chunk_meanings` lookup table from `chunk_meanings.h`.
 
-### pngcp (pngcp.c + pngread.c + pngwrite.c + inflateraster.c, ~350 lines total)
+### pngcp (pngcp.c + pngread.c + pngwrite.c + inflateraster.c)
 
 Copies a PNG file while optionally changing bit depth (`-d`) and/or
 the number of samples per pixel (`-s`). The pipeline is:
@@ -161,10 +161,11 @@ Additional generated test images in `testdata/` (created by
 | interlaced.png         | 32x32      | 8         | RGB (Adam7)        |
 | with_text.png          | 32x32      | 8         | RGB + tEXt chunks  |
 | with_transparency.png  | 32x32      | 8         | Paletted + tRNS    |
+| text_after_idat.png    | 8x8        | 8         | RGB + post-IDAT tEXt |
 
 ## Test Suite
 
-55 automated tests using Python testtools + stestr, organised into
+Automated tests use Python testtools + stestr, organised into
 four test modules matching the four tools:
 
 - `tests/test_pnginfo.py` -- metadata, tiff mode, bitmap dump, errors

--- a/pnginfo.c
+++ b/pnginfo.c
@@ -256,6 +256,41 @@ pnginfo_displayfile(const char *filename, int extractBitmap, int displayBitmap, 
   // FillOrder is always msb-to-lsb, big endian
   printf("  FillOrder: msb-to-lsb\n  Byte Order: Network (Big Endian)\n");
 
+  // Always read the image data so that tEXt/iTXt/zTXt chunks placed
+  // after IDAT become visible via png_get_text. Transforms (packing,
+  // palette expansion) only matter when we will dump the bitmap.
+  // See https://bugs.launchpad.net/ubuntu/+source/pngtools/+bug/1989739
+  if (extractBitmap == pnginfo_true)
+    {
+      if (bitdepth < 8)
+        png_set_packing(png);
+
+      if (colourtype == PNG_COLOR_TYPE_PALETTE)
+        png_set_expand(png);
+    }
+
+  // Required for Adam7 PNGs before png_read_image.
+  png_set_interlace_handling(png);
+
+  png_read_update_info(png, info);
+
+  rowbytes = png_get_rowbytes(png, info);
+  if ((bitmap = malloc((rowbytes * height) + 1)) == NULL)
+    {
+      fprintf(stderr, "Could not allocate memory for bitmap\n");
+      goto error;
+    }
+  if ((row_pointers = malloc(height * sizeof(png_bytep))) == NULL)
+    {
+      fprintf(stderr, "Could not allocate memory for row pointers\n");
+      goto error;
+    }
+
+  for (i = 0; i < height; ++i)
+    row_pointers[i] = bitmap + (i * rowbytes);
+  png_read_image(png, row_pointers);
+  png_read_end(png, info);
+
   png_textp text;
   int num_text, ti;
   num_text = png_get_text(png, info, &text, NULL);
@@ -308,39 +343,8 @@ pnginfo_displayfile(const char *filename, int extractBitmap, int displayBitmap, 
   // Print a blank line
   printf("\n");
 
-  // Do we want to extract the image data? We are meant to tell the user if
-  // there are errors, but we don't currently trap any errors here -- I need
-  // to look into this
   if (extractBitmap == pnginfo_true)
     {
-      // This will force the samples to be packed to the byte boundary
-      if (bitdepth < 8)
-        png_set_packing(png);
-
-      if (colourtype == PNG_COLOR_TYPE_PALETTE)
-        png_set_expand(png);
-
-      // png_set_strip_alpha (png);
-      png_read_update_info(png, info);
-
-      rowbytes = png_get_rowbytes(png, info);
-      if ((bitmap = malloc((rowbytes * height) + 1)) == NULL)
-        {
-          fprintf(stderr, "Could not allocate memory for bitmap\n");
-          goto error;
-        }
-      if ((row_pointers = malloc(height * sizeof(png_bytep))) == NULL)
-        {
-          fprintf(stderr, "Could not allocate memory for row pointers\n");
-          goto error;
-        }
-
-      // Get the image bitmap
-      for (i = 0; i < height; ++i)
-        row_pointers[i] = bitmap + (i * rowbytes);
-      png_read_image(png, row_pointers);
-      png_read_end(png, NULL);
-
       // Do we want to display this bitmap?
       if (displayBitmap == pnginfo_true)
         {

--- a/tests/base.py
+++ b/tests/base.py
@@ -19,10 +19,22 @@ SAMPLE_DIR = PROJECT_ROOT
 TESTDATA_DIR = os.path.join(PROJECT_ROOT, 'testdata')
 
 
+REQUIRED_TEST_IMAGES = (
+    'paletted.png',
+    'interlaced.png',
+    'with_text.png',
+    'with_transparency.png',
+    'text_after_idat.png',
+)
+
+
 def _ensure_test_images():
-    """Generate test images if they don't exist yet."""
-    marker = os.path.join(TESTDATA_DIR, 'with_text.png')
-    if not os.path.exists(marker):
+    """Generate test images if any are missing."""
+    missing = any(
+        not os.path.exists(os.path.join(TESTDATA_DIR, name))
+        for name in REQUIRED_TEST_IMAGES
+    )
+    if missing:
         script = os.path.join(
             PROJECT_ROOT, 'tests', 'generate_test_images.py'
         )

--- a/tests/generate_test_images.py
+++ b/tests/generate_test_images.py
@@ -60,14 +60,42 @@ def generate_interlaced(output_dir):
 
 
 def _save_interlaced_png(img, path):
-    """Save a PNG with Adam7 interlacing using raw bytes."""
+    """Save a 24-bit RGB PNG with valid Adam7 interlacing.
+
+    Pillow's high-level save() does not honour interlace=1, so we
+    emit the seven Adam7 passes manually.
+    """
     import struct
     import zlib
 
     width, height = img.size
-    raw_data = img.tobytes()
+    pixels = img.tobytes()
+    stride = width * 3
 
-    # Build IHDR
+    # Adam7: (col_start, row_start, col_step, row_step) per pass.
+    passes = [
+        (0, 0, 8, 8),
+        (4, 0, 8, 8),
+        (0, 4, 4, 8),
+        (2, 0, 4, 4),
+        (0, 2, 2, 4),
+        (1, 0, 2, 2),
+        (0, 1, 1, 2),
+    ]
+
+    raw_stream = b''
+    for col_start, row_start, col_step, row_step in passes:
+        pass_w = (width - col_start + col_step - 1) // col_step
+        pass_h = (height - row_start + row_step - 1) // row_step
+        if pass_w <= 0 or pass_h <= 0:
+            continue
+        for y in range(row_start, height, row_step):
+            row = b'\x00'  # filter byte: None
+            for x in range(col_start, width, col_step):
+                off = y * stride + x * 3
+                row += pixels[off:off + 3]
+            raw_stream += row
+
     ihdr_data = struct.pack(
         '>IIBBBBB',
         width, height,
@@ -77,18 +105,9 @@ def _save_interlaced_png(img, path):
         0,  # filter
         1   # interlace (Adam7)
     )
-
-    # Build IDAT with filter byte (0 = None) per row
-    raw_rows = b''
-    stride = width * 3
-    for y in range(height):
-        raw_rows += b'\x00'  # filter byte
-        raw_rows += raw_data[y * stride:(y + 1) * stride]
-
-    compressed = zlib.compress(raw_rows)
+    compressed = zlib.compress(raw_stream)
 
     with open(path, 'wb') as f:
-        # PNG signature
         f.write(b'\x89PNG\r\n\x1a\n')
 
         def write_chunk(chunk_type, data):
@@ -115,6 +134,53 @@ def generate_with_text(output_dir):
         os.path.join(output_dir, 'with_text.png'),
         pnginfo=info
     )
+
+
+def generate_with_text_after_idat(output_dir):
+    """Create a PNG with a tEXt chunk placed *after* IDAT.
+
+    Regression coverage for
+    https://bugs.launchpad.net/ubuntu/+source/pngtools/+bug/1989739
+    The PNG spec permits text chunks either side of IDAT, and
+    `exiftool` historically wrote them at the tail of the file.
+    Earlier pnginfo called png_get_text before consuming IDAT,
+    so post-IDAT text chunks were invisible.
+    """
+    import struct
+    import zlib
+
+    width, height = 8, 8
+    img = Image.new('RGB', (width, height), color=(50, 100, 150))
+    raw = img.tobytes()
+
+    ihdr = struct.pack(
+        '>IIBBBBB', width, height, 8, 2, 0, 0, 0
+    )
+
+    stride = width * 3
+    rows = b''
+    for y in range(height):
+        rows += b'\x00' + raw[y * stride:(y + 1) * stride]
+    idat = zlib.compress(rows)
+
+    keyword = b'Description'
+    value = b'Hello, world!'
+    text_data = keyword + b'\x00' + value
+
+    def chunk(ctype, data):
+        crc = zlib.crc32(ctype + data) & 0xFFFFFFFF
+        return (
+            struct.pack('>I', len(data)) + ctype + data
+            + struct.pack('>I', crc)
+        )
+
+    path = os.path.join(output_dir, 'text_after_idat.png')
+    with open(path, 'wb') as f:
+        f.write(b'\x89PNG\r\n\x1a\n')
+        f.write(chunk(b'IHDR', ihdr))
+        f.write(chunk(b'IDAT', idat))
+        f.write(chunk(b'tEXt', text_data))
+        f.write(chunk(b'IEND', b''))
 
 
 def generate_with_transparency(output_dir):
@@ -151,6 +217,7 @@ def main():
     generate_paletted(output_dir)
     generate_interlaced(output_dir)
     generate_with_text(output_dir)
+    generate_with_text_after_idat(output_dir)
     generate_with_transparency(output_dir)
 
     print(f'Generated test images in {output_dir}')

--- a/tests/test_pnginfo.py
+++ b/tests/test_pnginfo.py
@@ -115,6 +115,20 @@ class TestPnginfoGeneratedImages(base.PngtoolsTestCase):
         self.assertEqual(0, result.returncode)
         self.assertIn('Adam7 interlacing', result.stdout)
 
+    def test_interlaced_image_bitmap_dump(self):
+        """-D on an Adam7 image succeeds.
+
+        Decoding interlaced PNGs requires
+        png_set_interlace_handling before png_read_image; without
+        it libpng aborts with 'bad adaptive filter value'.
+        """
+        result = self.run_pnginfo(
+            self.generated_path('interlaced.png'), flags=['-D']
+        )
+        self.assertEqual(0, result.returncode)
+        self.assertNotIn('bad adaptive filter', result.stderr)
+        self.assertIn('Adam7 interlacing', result.stdout)
+
     def test_text_chunks(self):
         """with_text.png shows text chunk metadata."""
         result = self.run_pnginfo(
@@ -124,6 +138,20 @@ class TestPnginfoGeneratedImages(base.PngtoolsTestCase):
         self.assertIn('Number of text strings: 2', result.stdout)
         self.assertIn('Author', result.stdout)
         self.assertIn('Description', result.stdout)
+
+    def test_text_chunks_after_idat(self):
+        """text_after_idat.png: tEXt placed after IDAT is visible.
+
+        Regression coverage for
+        https://bugs.launchpad.net/ubuntu/+source/pngtools/+bug/1989739
+        """
+        result = self.run_pnginfo(
+            self.generated_path('text_after_idat.png')
+        )
+        self.assertEqual(0, result.returncode)
+        self.assertIn('Number of text strings: 1', result.stdout)
+        self.assertIn('Description', result.stdout)
+        self.assertIn('Hello, world!', result.stdout)
 
     def test_paletted_with_transparency(self):
         """with_transparency.png shows paletted with alpha."""


### PR DESCRIPTION
pnginfo called png_get_text immediately after png_read_info, which only exposes text chunks that appear before IDAT. PNG files where tEXt/iTXt/zTXt land after IDAT (allowed by the spec, and historically emitted by exiftool) showed "Number of text strings: 0" even though the metadata was present. Read the image data (png_read_image + png_read_end) before consulting png_get_text so chunks on either side of IDAT are visible. Apply the packing/expand transforms only when the user actually asked to dump the bitmap.

Adding the unconditional png_read_image surfaced a second latent bug: Adam7 PNGs need png_set_interlace_handling before png_read_image, or libpng aborts with "bad adaptive filter value". That code path was previously only reached via -d/-D and apparently never exercised on an interlaced file. Add the call unconditionally.

The interlaced test image was itself malformed -- it declared interlace=1 in IHDR but wrote pixels in row-major (non-Adam7) order. Rewrite generate_test_images.py to emit a proper seven-pass Adam7 stream, and add tests covering both the post-IDAT tEXt case and the -D bitmap dump on an interlaced PNG.

Fixes the Ubuntu reproducer in
https://bugs.launchpad.net/ubuntu/+source/pngtools/+bug/1989739. Fixes #36.

Also drop the per-tool line counts and the test count from AGENTS.md / ARCHITECTURE.md, since they cause churn on every change without conveying much.

Prompt: Reproduce the Ubuntu pngtools bug 1989739 ("pnginfo shows 0 of 0 text strings"). After confirming the bug is real when tEXt follows IDAT, add a Python regression test that fails before any code change and passes after, then fix pnginfo. While doing so, add a regression test for the interlacing handling that the fix incidentally needed, and drop the brittle test/line counts from the docs.