### PR TITLE
Add packaging status section to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ several Linux distributions.
 - **pngcp**: Copy a PNG file while optionally changing the bit depth
   (`-d`) and number of samples per pixel (`-s`).
 
+## Packaging status
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/pngtools.svg?minversion=1.3)](https://repology.org/project/pngtools/versions)
+
+The badge above (via [Repology](https://repology.org/project/pngtools/versions))
+shows the pngtools version each distribution currently ships. Find your
+distribution in the list: green means it is up to date with the current
+upstream release, red means it is behind. Note that GitHub caches badge
+images, so the badge can lag the live data on Repology by a while.
+
 ## Building
 
 Requires libpng-dev and optionally docbook-utils (for man pages):


### PR DESCRIPTION
Embed Repology's vertical-allrepos badge so users can see, at a glance, which pngtools version each distribution ships and whether their distro is behind current upstream. The badge uses minversion=1.3 so distributions below the current release render as outdated regardless of what Repology has ingested, and a short caption explains how to read the colours and notes that GitHub's image caching can make the badge lag Repology's live data.

Prompt: After discussing how to surface package staleness/divergence to users, add a "Packaging status" section to the pngtools README containing the Repology vertical-allrepos badge, with a caption that sets expectations about colour meaning and GitHub badge-cache staleness.


Assisted-By: Claude Opus 4.8 (1M context, medium effort) <noreply@anthropic.com>